### PR TITLE
Remove assumption that spaces are always valid separators

### DIFF
--- a/lib/stopword.js
+++ b/lib/stopword.js
@@ -1,5 +1,8 @@
 var _ = require('lodash');
 
+var tokenSeparator = '￭';
+exports.tokenSeparator = tokenSeparator;
+
 exports.removeStopwords = function(text, options) {
   var defaults = {
     'stopwords': require('./stopwords_en.js').words,
@@ -12,7 +15,7 @@ exports.removeStopwords = function(text, options) {
     if (options.stopwords.indexOf(value.toLowerCase()) != -1) return '';
     return value.toLowerCase();
   }));
-  return tokens.join(options.outputSeparator);
+  return tokens.join(tokenSeparator);
 }
 
 exports.getStopwords = function(lang) {


### PR DESCRIPTION
Corrects the assumption that spaces are always a valid token separator and instead delimits tokens using the `￭` Unicode character. Also exposes a `tokenSeparator` property that allows other modules to access the token separator string without hard-coding it themselves.