### PR TITLE
Fix amelyből

### DIFF
--- a/src/stopwords_hun.js
+++ b/src/stopwords_hun.js
@@ -35,7 +35,7 @@ const hun = [
   'alóluk',
   'alólunk',
   'amely',
-  'amelybol',
+  'amelyből',
   'amelyek',
   'amelyekben',
   'amelyeket',


### PR DESCRIPTION
There is no such Hungarian word that "amelybol", it's "amelyből"