### PR TITLE
Remove trailing space in "stopwords_nld.js"

### DIFF
--- a/src/stopwords_nld.js
+++ b/src/stopwords_nld.js
@@ -69,7 +69,7 @@ const nld = [
   'in',
   'is',
   'ja',
-  'je ',
+  'je',
   'kan',
   'kon',
   'kunnen',


### PR DESCRIPTION
Removes trailing space after `je ,`. Not an issue if `.trim()` is called, but couldn't find it in `removeStopwords`
